### PR TITLE
Reformat code, documentation/enumerator correctness fixes

### DIFF
--- a/src/Lumina/Excel/BaseExcelSheet.cs
+++ b/src/Lumina/Excel/BaseExcelSheet.cs
@@ -163,7 +163,7 @@ public abstract class BaseExcelSheet
             _rowIndexLookupDict = FrozenDictionary< int, int >.Empty;
             _rowIndexLookupArray = [];
             _rowIndexLookupArrayOffset = 0;
-            _rowOffsetLookupTable = [default]; // so that _rowOffsetLookupTable.UnsafeAt(0) is always valid.
+            _rowOffsetLookupTable = [];
             Count = 0;
         }
     }

--- a/src/Lumina/Excel/BaseExcelSheet.cs
+++ b/src/Lumina/Excel/BaseExcelSheet.cs
@@ -123,10 +123,10 @@ public abstract class BaseExcelSheet
             var numUnused = numSlots - headerFile.Header.RowCount;
             if( numUnused <= MaxUnusedLookupItemCount )
             {
-                _rowIndexLookupArray = new int[ numSlots ];
+                _rowIndexLookupArray = new int[numSlots];
                 _rowIndexLookupArray.AsSpan().Fill( -1 );
-                for (i = 0; i < _rowOffsetLookupTable.Length; i++)
-                    _rowIndexLookupArray[_rowOffsetLookupTable[ i ].RowId - firstId] = i;
+                for( i = 0; i < _rowOffsetLookupTable.Length; i++ )
+                    _rowIndexLookupArray[ _rowOffsetLookupTable[ i ].RowId - firstId ] = i;
 
                 // All items can be looked up from _rowIndexLookupArray. Dictionary is unnecessary.
                 _rowIndexLookupDict = FrozenDictionary< int, int >.Empty;
@@ -215,15 +215,15 @@ public abstract class BaseExcelSheet
             throw new ArgumentException( "Invalid sheet name", nameof( sheetName ) );
 
         if( module.VerifySheetChecksums && columnHash is { } hash && headerFile.GetColumnsHash() != hash )
-            throw new MismatchedColumnHashException(hash, headerFile.GetColumnsHash(), nameof(columnHash) );
+            throw new MismatchedColumnHashException( hash, headerFile.GetColumnsHash(), nameof( columnHash ) );
 
         if( !headerFile.Languages.Contains( language ) )
             throw new UnsupportedLanguageException();
 
         return headerFile.Header.Variant switch
         {
-            ExcelVariant.Default => new ExcelSheet<T>( module, headerFile, language, sheetName ),
-            ExcelVariant.Subrows => new SubrowExcelSheet<T>( module, headerFile, language, sheetName ),
+            ExcelVariant.Default => new ExcelSheet< T >( module, headerFile, language, sheetName ),
+            ExcelVariant.Subrows => new SubrowExcelSheet< T >( module, headerFile, language, sheetName ),
             _ => throw new NotSupportedException( $"Specified sheet variant {headerFile.Header.Variant} is not supported." ),
         };
     }
@@ -260,18 +260,18 @@ public abstract class BaseExcelSheet
     [MethodImpl( MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization )]
     internal ref readonly RowOffsetLookup GetRowLookupOrNullRef( uint rowId )
     {
-        var lookupArrayIndex = unchecked( rowId - _rowOffsetLookupTable.UnsafeAt(0).RowId );
+        var lookupArrayIndex = unchecked( rowId - _rowOffsetLookupTable.UnsafeAt( 0 ).RowId );
         if( lookupArrayIndex < _rowIndexLookupArray.Length )
         {
             var rowIndex = _rowIndexLookupArray.UnsafeAt( (int) lookupArrayIndex );
-            if (rowIndex == -1)
-                return ref Unsafe.NullRef<RowOffsetLookup>();
+            if( rowIndex == -1 )
+                return ref Unsafe.NullRef< RowOffsetLookup >();
             return ref UnsafeGetRowLookupAt( rowIndex );
         }
 
         ref readonly var rowIndexRef = ref _rowIndexLookupDict.GetValueRefOrNullRef( (int) rowId );
         if( Unsafe.IsNullRef( in rowIndexRef ) )
-            return ref Unsafe.NullRef<RowOffsetLookup>();
+            return ref Unsafe.NullRef< RowOffsetLookup >();
         return ref UnsafeGetRowLookupAt( rowIndexRef );
     }
 
@@ -279,7 +279,7 @@ public abstract class BaseExcelSheet
     /// <param name="rowIndex">Index of the desired row.</param>
     /// <returns>Lookup data for the desired row.</returns>
     internal ref readonly RowOffsetLookup UnsafeGetRowLookupAt( int rowIndex ) =>
-        ref _rowOffsetLookupTable.UnsafeAt(rowIndex);
+        ref _rowOffsetLookupTable.UnsafeAt( rowIndex );
 
     /// <summary>Creates a row at the given index, without checking for bounds or preconditions.</summary>
     /// <param name="rowIndex">Index of the desired row.</param>
@@ -299,7 +299,7 @@ public abstract class BaseExcelSheet
     /// <returns>A new instance of <typeparamref name="T"/>.</returns>
     internal T UnsafeCreateRow< T >( scoped ref readonly RowOffsetLookup lookup ) where T : struct, IExcelRow< T > =>
         T.Create(
-            _pages.UnsafeAt(lookup.PageIndex),
+            _pages.UnsafeAt( lookup.PageIndex ),
             lookup.Offset,
             lookup.RowId );
 
@@ -309,7 +309,7 @@ public abstract class BaseExcelSheet
     /// <returns>A new instance of <typeparamref name="T"/>.</returns>
     internal T UnsafeCreateSubrow< T >( scoped ref readonly RowOffsetLookup lookup, ushort subrowId ) where T : struct, IExcelRow< T > =>
         T.Create(
-            _pages.UnsafeAt(lookup.PageIndex),
+            _pages.UnsafeAt( lookup.PageIndex ),
             lookup.Offset + 2 + subrowId * ( _subrowDataOffset + 2u ),
             lookup.RowId,
             subrowId );

--- a/src/Lumina/Excel/Collection.cs
+++ b/src/Lumina/Excel/Collection.cs
@@ -15,37 +15,39 @@ namespace Lumina.Excel;
 /// <param name="offset"></param>
 /// <param name="ctor"></param>
 /// <param name="size"></param>
-public readonly struct Collection<T>( ExcelPage page, uint parentOffset, uint offset, Func<ExcelPage, uint, uint, uint, T> ctor, int size ) : IReadOnlyList<T>, ICollection<T> where T : struct
+public readonly struct Collection< T >( ExcelPage page, uint parentOffset, uint offset, Func< ExcelPage, uint, uint, uint, T > ctor, int size )
+    : IReadOnlyList< T >, ICollection< T > where T : struct
 {
     /// <inheritdoc/>
-    public T this[int index] {
+    public T this[ int index ] {
         [MethodImpl( MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization )]
         get {
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual( index, size );
-            return ctor( page, parentOffset, offset, (uint)index );
+            return ctor( page, parentOffset, offset, (uint) index );
         }
     }
 
     /// <inheritdoc/>
     public int Count => size;
 
-    bool ICollection<T>.IsReadOnly => true;
+    bool ICollection< T >.IsReadOnly => true;
 
-    void ICollection<T>.Add( T item ) => throw new NotSupportedException();
+    void ICollection< T >.Add( T item ) => throw new NotSupportedException();
 
-    void ICollection<T>.Clear() => throw new NotSupportedException();
+    void ICollection< T >.Clear() => throw new NotSupportedException();
 
-    bool ICollection<T>.Remove( T item ) => throw new NotSupportedException();
+    bool ICollection< T >.Remove( T item ) => throw new NotSupportedException();
 
     /// <inheritdoc/>
     public bool Contains( T item )
     {
-        var comparer = EqualityComparer<T>.Default;
-        foreach (var element in this )
+        var comparer = EqualityComparer< T >.Default;
+        foreach( var element in this )
         {
             if( comparer.Equals( item, element ) )
                 return true;
         }
+
         return false;
     }
 
@@ -56,25 +58,25 @@ public readonly struct Collection<T>( ExcelPage page, uint parentOffset, uint of
         ArgumentOutOfRangeException.ThrowIfNegative( arrayIndex );
         if( Count > array.Length - arrayIndex )
             throw new ArgumentException( "The number of elements in the source list is greater than the available space." );
-        for (var i = 0; i < Count; i++ )
-            array[ arrayIndex++ ] = this[i];
+        for( var i = 0; i < Count; i++ )
+            array[ arrayIndex++ ] = this[ i ];
     }
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
     public Enumerator GetEnumerator() => new( this );
 
-    readonly IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+    readonly IEnumerator< T > IEnumerable< T >.GetEnumerator() => GetEnumerator();
 
     readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>Enumerator that enumerates over the different items.</summary>
     /// <param name="collection">Collection to iterate over.</param>
-    public struct Enumerator( Collection<T> collection ) : IEnumerator<T>
+    public struct Enumerator( Collection< T > collection ) : IEnumerator< T >
     {
         private int _index = -1;
 
         /// <inheritdoc cref="IEnumerator{T}.Current"/>
-        public readonly T Current => collection[_index];
+        public readonly T Current => collection[ _index ];
 
         readonly object IEnumerator.Current => Current;
 

--- a/src/Lumina/Excel/ExcelModule.cs
+++ b/src/Lumina/Excel/ExcelModule.cs
@@ -169,8 +169,8 @@ public class ExcelModule
         public Exception Exception { get; private set; }
 
         // never actually called
-        private InvalidSheet( ExcelModule module, ExcelHeaderFile headerFile, Language requestedLanguage, string sheetName ) : base( module, headerFile,
-            requestedLanguage, sheetName )
+        private InvalidSheet( ExcelModule module, ExcelHeaderFile headerFile, Language requestedLanguage, string sheetName )
+            : base( module, headerFile, requestedLanguage, sheetName )
         {
             Exception = null!;
         }

--- a/src/Lumina/Excel/ExcelModule.cs
+++ b/src/Lumina/Excel/ExcelModule.cs
@@ -61,7 +61,7 @@ public class ExcelModule
 
     /// <summary>Loads an <see cref="ExcelSheet{T}"/>.</summary>
     /// <exception cref="InvalidCastException">Sheet is not of the variant <see cref="ExcelVariant.Default"/>.</exception>
-    /// <inheritdoc cref="GetSubrowSheet{T}(Language?)"/>
+    /// <inheritdoc cref="GetSubrowSheet{T}(Nullable{Lumina.Data.Language})"/>
     public ExcelSheet< T > GetSheet< T >( Language? language = null ) where T : struct, IExcelRow< T > =>
         (ExcelSheet< T >) GetBaseSheet< T >( language );
 
@@ -72,7 +72,7 @@ public class ExcelModule
     /// <see cref="UnsupportedLanguageException"/>.</para>
     /// </remarks>
     /// <exception cref="InvalidCastException">Sheet is not of the variant <see cref="ExcelVariant.Subrows"/>.</exception>
-    /// <inheritdoc cref="GetBaseSheet{T}(Language?)"/>
+    /// <inheritdoc cref="GetBaseSheet{T}(Nullable{Lumina.Data.Language})"/>
     public SubrowExcelSheet< T > GetSubrowSheet< T >( Language? language = null ) where T : struct, IExcelRow< T > =>
         (SubrowExcelSheet< T >) GetBaseSheet< T >( language );
 
@@ -86,7 +86,7 @@ public class ExcelModule
     /// before accessing its rows.</para>
     /// </remarks>
     /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not have a valid <see cref="SheetAttribute"/>.</exception>
-    /// <inheritdoc cref="GetBaseSheet(Type, Language?)"/>
+    /// <inheritdoc cref="GetBaseSheet(Type, Nullable{Lumina.Data.Language})"/>
     [EditorBrowsable( EditorBrowsableState.Advanced )]
     public BaseExcelSheet GetBaseSheet< T >( Language? language = null ) where T : struct, IExcelRow< T > =>
         GetBaseSheet( typeof( T ), language );
@@ -113,21 +113,37 @@ public class ExcelModule
     [EditorBrowsable( EditorBrowsableState.Advanced )]
     public BaseExcelSheet GetBaseSheet( Type rowType, Language? language = null )
     {
-        if( !rowType.IsValueType )
-            throw new ArgumentException( $"{nameof( rowType )} must be a struct.", nameof( rowType ) );
-
-        if( !rowType.IsAssignableTo( typeof( IExcelRow<> ).MakeGenericType( rowType ) ) )
-            throw new ArgumentException( $"{nameof( rowType )} must implement {typeof( IExcelRow<> ).Name}.", nameof( rowType ) );
-
         var sheet = SheetCache.GetOrAdd(
             ( rowType, language ?? Language ),
             static ( key, module ) => {
-                var m = typeof( BaseExcelSheet )
-                    .GetMethod( nameof( BaseExcelSheet.From ), BindingFlags.Static | BindingFlags.Public )!
-                    .MakeGenericMethod( key.Type );
+                MethodInfo m;
+                try
+                {
+                    // As BaseExcelSheet.From<T> has a constraint that T : IExcelRow<T>, it is implicitly required that T is also a struct.
+                    // MakeGenericMethod will check for constraints, and throw ArgumentException if constraints aren't met.
+                    m = typeof( BaseExcelSheet )
+                        .GetMethod(
+                            nameof( BaseExcelSheet.From ),
+                            BindingFlags.Static | BindingFlags.Public,
+                            [typeof( ExcelModule ), typeof( Language )] )!
+                        .MakeGenericMethod( key.Type );
+                }
+                catch( ArgumentException e )
+                {
+                    // Exception thrown here will propagate outside ConcurrentDictionary<>.GetOrAdd without touching the data stored inside dictionary.
+                    throw new ArgumentException(
+                        $"{key.Type.Name} must implement {typeof( IExcelRow<> ).Name.Split( '`', 2 )[ 0 ]}<{key.Type.Name}>.",
+                        nameof( rowType ),
+                        e );
+                }
+
                 try
                 {
                     return m.Invoke( null, [module, key.Language] ) as BaseExcelSheet ?? throw new InvalidOperationException( "Something went wrong" );
+                }
+                catch( TargetInvocationException e )
+                {
+                    return InvalidSheet.Create( e.InnerException ?? e );
                 }
                 catch( Exception e )
                 {

--- a/src/Lumina/Excel/ExcelModule.cs
+++ b/src/Lumina/Excel/ExcelModule.cs
@@ -88,7 +88,7 @@ public class ExcelModule
     /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not have a valid <see cref="SheetAttribute"/>.</exception>
     /// <inheritdoc cref="GetBaseSheet(Type, Language?)"/>
     [EditorBrowsable( EditorBrowsableState.Advanced )]
-    public BaseExcelSheet GetBaseSheet<T>( Language? language = null ) where T : struct, IExcelRow<T> =>
+    public BaseExcelSheet GetBaseSheet< T >( Language? language = null ) where T : struct, IExcelRow< T > =>
         GetBaseSheet( typeof( T ), language );
 
     /// <summary>Loads an <see cref="BaseExcelSheet"/>.</summary>
@@ -144,6 +144,7 @@ public class ExcelModule
                 throw new UnsupportedLanguageException( nameof( language ), language, null );
             return GetBaseSheet( rowType, Language.None );
         }
+
         throw e;
     }
 
@@ -152,14 +153,15 @@ public class ExcelModule
         public Exception Exception { get; private set; }
 
         // never actually called
-        private InvalidSheet( ExcelModule module, ExcelHeaderFile headerFile, Language requestedLanguage, string sheetName ) : base(module, headerFile, requestedLanguage, sheetName)
+        private InvalidSheet( ExcelModule module, ExcelHeaderFile headerFile, Language requestedLanguage, string sheetName ) : base( module, headerFile,
+            requestedLanguage, sheetName )
         {
             Exception = null!;
         }
 
-        public static InvalidSheet Create(Exception exception )
+        public static InvalidSheet Create( Exception exception )
         {
-            var ret = (InvalidSheet)RuntimeHelpers.GetUninitializedObject( typeof( InvalidSheet ) );
+            var ret = (InvalidSheet) RuntimeHelpers.GetUninitializedObject( typeof( InvalidSheet ) );
             ret.Exception = exception;
             return ret;
         }

--- a/src/Lumina/Excel/ExcelPage.cs
+++ b/src/Lumina/Excel/ExcelPage.cs
@@ -23,7 +23,7 @@ public sealed class ExcelPage
     public ExcelModule Module { get; }
 
     private readonly byte[] data;
-    private ReadOnlyMemory<byte> Data => data;
+    private ReadOnlyMemory< byte > Data => data;
 
     private readonly ushort dataOffset;
 
@@ -37,12 +37,12 @@ public sealed class ExcelPage
     // Ignores bounds checks to speed up reading data.
     // https://t.ly/EmR4n (Sharplab link)
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
-    private D Read<D>( nuint offset ) where D : unmanaged =>
-        Unsafe.As<byte, D>( ref Unsafe.AddByteOffset( ref MemoryMarshal.GetArrayDataReference( data ), offset ) );
+    private D Read< D >( nuint offset ) where D : unmanaged =>
+        Unsafe.As< byte, D >( ref Unsafe.AddByteOffset( ref MemoryMarshal.GetArrayDataReference( data ), offset ) );
 
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     private static float ReverseEndianness( float v ) =>
-        Unsafe.BitCast<uint, float>( BinaryPrimitives.ReverseEndianness( Unsafe.BitCast<float, uint>( v ) ) );
+        Unsafe.BitCast< uint, float >( BinaryPrimitives.ReverseEndianness( Unsafe.BitCast< float, uint >( v ) ) );
 
     /// <summary>
     /// Reads a <see cref="ReadOnlySeString"/> from the page data at <paramref name="offset"/>.
@@ -57,14 +57,15 @@ public sealed class ExcelPage
     public ReadOnlySeString ReadString( nuint offset, nuint structOffset )
     {
         offset = ReadUInt32( offset ) + structOffset + dataOffset;
-        var data = Data[(int)offset..];
-        var stringLength = data.Span.IndexOf( (byte)0 );
-        var ret = new ReadOnlySeString( data[..stringLength] );
+        var data = Data[ (int) offset.. ];
+        var stringLength = data.Span.IndexOf( (byte) 0 );
+        var ret = new ReadOnlySeString( data[ ..stringLength ] );
         if( ret.IsRsv() && Module.RsvResolver != null )
         {
             if( Module.RsvResolver.Invoke( ret, out var resolvedString ) )
                 return resolvedString;
         }
+
         return ret;
     }
 
@@ -75,7 +76,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="bool"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public bool ReadBool( nuint offset ) =>
-        Read<bool>( offset );
+        Read< bool >( offset );
 
     /// <summary>
     /// Reads a <see cref="sbyte"/> from the page data at <paramref name="offset"/>.
@@ -84,7 +85,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="sbyte"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public sbyte ReadInt8( nuint offset ) =>
-        Read<sbyte>( offset );
+        Read< sbyte >( offset );
 
     /// <summary>
     /// Reads a <see cref="byte"/> from the page data at <paramref name="offset"/>.
@@ -93,7 +94,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="byte"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public byte ReadUInt8( nuint offset ) =>
-        Read<byte>( offset );
+        Read< byte >( offset );
 
     /// <summary>
     /// Reads a <see cref="short"/> from the page data at <paramref name="offset"/>.
@@ -102,7 +103,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="short"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public short ReadInt16( nuint offset ) =>
-        BinaryPrimitives.ReverseEndianness( Read<short>( offset ) );
+        BinaryPrimitives.ReverseEndianness( Read< short >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="ushort"/> from the page data at <paramref name="offset"/>.
@@ -111,7 +112,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="ushort"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public ushort ReadUInt16( nuint offset ) =>
-        BinaryPrimitives.ReverseEndianness( Read<ushort>( offset ) );
+        BinaryPrimitives.ReverseEndianness( Read< ushort >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="int"/> from the page data at <paramref name="offset"/>.
@@ -120,7 +121,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="int"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public int ReadInt32( nuint offset ) =>
-        BinaryPrimitives.ReverseEndianness( Read<int>( offset ) );
+        BinaryPrimitives.ReverseEndianness( Read< int >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="uint"/> from the page data at <paramref name="offset"/>.
@@ -129,7 +130,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="uint"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public uint ReadUInt32( nuint offset ) =>
-        BinaryPrimitives.ReverseEndianness( Read<uint>( offset ) );
+        BinaryPrimitives.ReverseEndianness( Read< uint >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="float"/> from the page data at <paramref name="offset"/>.
@@ -138,7 +139,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="float"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public float ReadFloat32( nuint offset ) =>
-        ReverseEndianness( Read<float>( offset ) );
+        ReverseEndianness( Read< float >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="long"/> from the page data at <paramref name="offset"/>.
@@ -147,7 +148,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="long"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public long ReadInt64( nuint offset ) =>
-        BinaryPrimitives.ReverseEndianness( Read<long>( offset ) );
+        BinaryPrimitives.ReverseEndianness( Read< long >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="ulong"/> from the page data at <paramref name="offset"/>.
@@ -156,7 +157,7 @@ public sealed class ExcelPage
     /// <returns>The <see cref="ulong"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public ulong ReadUInt64( nuint offset ) =>
-        BinaryPrimitives.ReverseEndianness( Read<ulong>( offset ) );
+        BinaryPrimitives.ReverseEndianness( Read< ulong >( offset ) );
 
     /// <summary>
     /// Reads a <see cref="bool"/> from the page data at <paramref name="offset"/> at bit offset <paramref name="bit"/>.
@@ -166,5 +167,5 @@ public sealed class ExcelPage
     /// <returns>The <see cref="ulong"/>.</returns>
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     public bool ReadPackedBool( nuint offset, byte bit ) =>
-        ( Read<byte>( offset ) & ( 1 << bit ) ) != 0;
+        ( Read< byte >( offset ) & ( 1 << bit ) ) != 0;
 }

--- a/src/Lumina/Excel/ExcelSheet.cs
+++ b/src/Lumina/Excel/ExcelSheet.cs
@@ -111,7 +111,7 @@ public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection< T >, IReadOnl
         private int _index = -1;
 
         /// <inheritdoc cref="IEnumerator{T}.Current"/>
-        public readonly T Current => sheet.UnsafeCreateRowAt< T >( _index );
+        public T Current { get; private set; }
 
         readonly object IEnumerator.Current => Current;
 
@@ -119,15 +119,20 @@ public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection< T >, IReadOnl
         public bool MoveNext()
         {
             if( ++_index < sheet.Count )
+            {
+                // UnsafeCreateRowAt must be called only when the preconditions are validated.
+                // If it is to be called on-demand from get_Current, then it may end up being called with invalid parameters,
+                // so we create the instance in advance here.
+                Current = sheet.UnsafeCreateRowAt< T >( _index );
                 return true;
+            }
 
             --_index;
             return false;
         }
 
         /// <inheritdoc/>
-        public void Reset() =>
-            _index = -1;
+        public void Reset() => _index = -1;
 
         /// <inheritdoc/>
         public readonly void Dispose()

--- a/src/Lumina/Excel/ExcelSheet.cs
+++ b/src/Lumina/Excel/ExcelSheet.cs
@@ -10,7 +10,7 @@ namespace Lumina.Excel;
 
 /// <summary>An excel sheet of <see cref="ExcelVariant.Default"/> variant.</summary>
 /// <typeparam name="T">Type of the rows contained within.</typeparam>
-public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection<T>, IReadOnlyCollection<T> where T : struct, IExcelRow< T >
+public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection< T >, IReadOnlyCollection< T > where T : struct, IExcelRow< T >
 {
     internal ExcelSheet( ExcelModule module, ExcelHeaderFile headerFile, Language requestedLanguage, string sheetName )
         : base( module, headerFile, requestedLanguage, sheetName )
@@ -29,7 +29,7 @@ public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection<T>, IReadOnlyC
     public T? GetRowOrDefault( uint rowId )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
-        return Unsafe.IsNullRef(in lookup) ? null : UnsafeCreateRow< T >( in lookup );
+        return Unsafe.IsNullRef( in lookup ) ? null : UnsafeCreateRow< T >( in lookup );
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection<T>, IReadOnlyC
     public bool TryGetRow( uint rowId, out T row )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
-        if( Unsafe.IsNullRef(in lookup) )
+        if( Unsafe.IsNullRef( in lookup ) )
         {
             row = default;
             return false;
@@ -60,7 +60,7 @@ public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection<T>, IReadOnlyC
     public T GetRow( uint rowId )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
-        return Unsafe.IsNullRef(in lookup) ? throw new ArgumentOutOfRangeException( nameof( rowId ), rowId, null ) : UnsafeCreateRow< T >( in lookup );
+        return Unsafe.IsNullRef( in lookup ) ? throw new ArgumentOutOfRangeException( nameof( rowId ), rowId, null ) : UnsafeCreateRow< T >( in lookup );
     }
 
     /// <summary>
@@ -87,8 +87,8 @@ public sealed class ExcelSheet< T > : BaseExcelSheet, ICollection<T>, IReadOnlyC
         ArgumentOutOfRangeException.ThrowIfNegative( arrayIndex );
         if( Count > array.Length - arrayIndex )
             throw new ArgumentException( "The number of elements in the source list is greater than the available space." );
-        foreach (var lookup in OffsetLookupTable)
-            array[ arrayIndex++ ] = UnsafeCreateRow<T>( in lookup );
+        foreach( var lookup in OffsetLookupTable )
+            array[ arrayIndex++ ] = UnsafeCreateRow< T >( in lookup );
     }
 
     void ICollection< T >.Add( T item ) => throw new NotSupportedException();

--- a/src/Lumina/Excel/IExcelRow.cs
+++ b/src/Lumina/Excel/IExcelRow.cs
@@ -6,7 +6,7 @@ namespace Lumina.Excel;
 /// Defines a row type/schema for an excel sheet.
 /// </summary>
 /// <typeparam name="T">The type that implements the interface.</typeparam>
-public interface IExcelRow< T > where T : struct
+public interface IExcelRow< out T > where T : struct
 {
     /// <summary>
     /// Creates an instance of the current type. Designed only for use within <see cref="Lumina"/>.
@@ -32,9 +32,9 @@ public interface IExcelRow< T > where T : struct
     abstract static T Create( ExcelPage page, uint offset, uint row, ushort subrow );
 
     /// <summary>Gets the row ID.</summary>
-    public uint RowId { get; }
+    uint RowId { get; }
 
     /// <summary>Gets the subrow ID.</summary>
     /// <exception cref="NotSupportedException">Thrown when the referenced sheet is not using subrows.</exception>
-    public ushort SubrowId { get; }
+    ushort SubrowId { get; }
 }

--- a/src/Lumina/Excel/IExcelRow.cs
+++ b/src/Lumina/Excel/IExcelRow.cs
@@ -6,7 +6,7 @@ namespace Lumina.Excel;
 /// Defines a row type/schema for an excel sheet.
 /// </summary>
 /// <typeparam name="T">The type that implements the interface.</typeparam>
-public interface IExcelRow<T> where T : struct
+public interface IExcelRow< T > where T : struct
 {
     /// <summary>
     /// Creates an instance of the current type. Designed only for use within <see cref="Lumina"/>.

--- a/src/Lumina/Excel/SubrowCollection.cs
+++ b/src/Lumina/Excel/SubrowCollection.cs
@@ -45,15 +45,15 @@ public readonly struct SubrowCollection< T > : IList< T >, IReadOnlyList< T >
         set => throw new NotSupportedException();
     }
 
-    void IList<T>.Insert( int index, T item ) => throw new NotSupportedException();
+    void IList< T >.Insert( int index, T item ) => throw new NotSupportedException();
 
-    void IList<T>.RemoveAt( int index ) => throw new NotSupportedException();
+    void IList< T >.RemoveAt( int index ) => throw new NotSupportedException();
 
-    void ICollection<T>.Add( T item ) => throw new NotSupportedException();
+    void ICollection< T >.Add( T item ) => throw new NotSupportedException();
 
-    void ICollection<T>.Clear() => throw new NotSupportedException();
+    void ICollection< T >.Clear() => throw new NotSupportedException();
 
-    bool ICollection<T>.Remove( T item ) => throw new NotSupportedException();
+    bool ICollection< T >.Remove( T item ) => throw new NotSupportedException();
 
     /// <inheritdoc/>
     public int IndexOf( T item )

--- a/src/Lumina/Excel/SubrowCollection.cs
+++ b/src/Lumina/Excel/SubrowCollection.cs
@@ -93,7 +93,7 @@ public readonly struct SubrowCollection< T > : IList< T >, IReadOnlyList< T >
         private int _index = -1;
 
         /// <inheritdoc cref="IEnumerator{T}.Current"/>
-        public readonly T Current => subrowCollection.Sheet.UnsafeCreateSubrow< T >( in subrowCollection._lookup, unchecked( (ushort) _index ) );
+        public T Current { get; private set; }
 
         readonly object IEnumerator.Current => Current;
 
@@ -101,7 +101,13 @@ public readonly struct SubrowCollection< T > : IList< T >, IReadOnlyList< T >
         public bool MoveNext()
         {
             if( ++_index < subrowCollection.Count )
+            {
+                // UnsafeCreateSubrow must be called only when the preconditions are validated.
+                // If it is to be called on-demand from get_Current, then it may end up being called with invalid parameters,
+                // so we create the instance in advance here.
+                Current = subrowCollection.Sheet.UnsafeCreateSubrow< T >( in subrowCollection._lookup, unchecked( (ushort) _index ) );
                 return true;
+            }
 
             --_index;
             return false;

--- a/src/Lumina/Excel/SubrowExcelSheet.cs
+++ b/src/Lumina/Excel/SubrowExcelSheet.cs
@@ -9,29 +9,29 @@ namespace Lumina.Excel;
 
 /// <typeparam name="T">Type of the rows contained within.</typeparam>
 /// <inheritdoc cref="BaseSubrowExcelSheet"/>
-public sealed class SubrowExcelSheet<T>
-    : BaseSubrowExcelSheet, ICollection<SubrowCollection<T>>, IReadOnlyCollection<SubrowCollection<T>>
-    where T : struct, IExcelRow<T>
+public sealed class SubrowExcelSheet< T >
+    : BaseSubrowExcelSheet, ICollection< SubrowCollection< T > >, IReadOnlyCollection< SubrowCollection< T > >
+    where T : struct, IExcelRow< T >
 {
     internal SubrowExcelSheet( ExcelModule module, ExcelHeaderFile headerFile, Language requestedLanguage, string sheetName )
         : base( module, headerFile, requestedLanguage, sheetName )
     { }
 
     /// <inheritdoc/>
-    bool ICollection<SubrowCollection<T>>.IsReadOnly => true;
+    bool ICollection< SubrowCollection< T > >.IsReadOnly => true;
 
     /// <inheritdoc cref="GetRow"/>
-    public SubrowCollection<T> this[uint rowId] => GetRow( rowId );
+    public SubrowCollection< T > this[ uint rowId ] => GetRow( rowId );
 
     /// <inheritdoc cref="GetSubrow"/>
-    public T this[uint rowId, ushort subrowId] => GetSubrow( rowId, subrowId );
+    public T this[ uint rowId, ushort subrowId ] => GetSubrow( rowId, subrowId );
 
     /// <summary>
     /// Tries to get the subrow collection with row id <paramref name="rowId"/> in this sheet.
     /// </summary>
     /// <param name="rowId">The row id to get.</param>
     /// <returns>A nullable subrow collection object. Returns <see langword="null"/> if the row does not exist.</returns>
-    public SubrowCollection<T>? GetRowOrDefault( uint rowId )
+    public SubrowCollection< T >? GetRowOrDefault( uint rowId )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
         return Unsafe.IsNullRef( in lookup ) ? null : new( this, in lookup );
@@ -43,7 +43,7 @@ public sealed class SubrowExcelSheet<T>
     /// <param name="rowId">The row id to get.</param>
     /// <param name="row">The output subrow collection object.</param>
     /// <returns><see langword="true"/> if the row exists and <paramref name="row"/> is written to and <see langword="false"/> otherwise.</returns>
-    public bool TryGetRow( uint rowId, out SubrowCollection<T> row )
+    public bool TryGetRow( uint rowId, out SubrowCollection< T > row )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
         if( Unsafe.IsNullRef( in lookup ) )
@@ -62,7 +62,7 @@ public sealed class SubrowExcelSheet<T>
     /// <param name="rowId">The row id to get.</param>
     /// <returns>A subrow collection object.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if the sheet does not have a row at that <paramref name="rowId"/>.</exception>
-    public SubrowCollection<T> GetRow( uint rowId )
+    public SubrowCollection< T > GetRow( uint rowId )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
         return Unsafe.IsNullRef( in lookup ) ? throw new ArgumentOutOfRangeException( nameof( rowId ), rowId, null ) : new( this, in lookup );
@@ -74,7 +74,7 @@ public sealed class SubrowExcelSheet<T>
     /// <remarks>If you are looking to find a row by its id, use <see cref="GetRow(uint)"/> instead.</remarks>
     /// <param name="rowIndex">The zero-based index of this row.</param>
     /// <returns>A subrow collection object.</returns>
-    public SubrowCollection<T> GetRowAt( int rowIndex )
+    public SubrowCollection< T > GetRowAt( int rowIndex )
     {
         ArgumentOutOfRangeException.ThrowIfNegative( rowIndex );
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual( rowIndex, OffsetLookupTable.Length );
@@ -91,7 +91,7 @@ public sealed class SubrowExcelSheet<T>
     public T? GetSubrowOrDefault( uint rowId, ushort subrowId )
     {
         ref readonly var lookup = ref GetRowLookupOrNullRef( rowId );
-        return Unsafe.IsNullRef( in lookup ) || subrowId >= lookup.SubrowCount ? null : UnsafeCreateSubrow<T>( in lookup, subrowId );
+        return Unsafe.IsNullRef( in lookup ) || subrowId >= lookup.SubrowCount ? null : UnsafeCreateSubrow< T >( in lookup, subrowId );
     }
 
     /// <summary>
@@ -110,7 +110,7 @@ public sealed class SubrowExcelSheet<T>
             return false;
         }
 
-        subrow = UnsafeCreateSubrow<T>( in lookup, subrowId );
+        subrow = UnsafeCreateSubrow< T >( in lookup, subrowId );
         return true;
     }
 
@@ -129,7 +129,7 @@ public sealed class SubrowExcelSheet<T>
 
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual( subrowId, lookup.SubrowCount );
 
-        return UnsafeCreateSubrow<T>( in lookup, subrowId );
+        return UnsafeCreateSubrow< T >( in lookup, subrowId );
     }
 
     /// <summary>
@@ -148,28 +148,28 @@ public sealed class SubrowExcelSheet<T>
         ref readonly var lookup = ref UnsafeGetRowLookupAt( rowIndex );
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual( subrowId, lookup.SubrowCount );
 
-        return UnsafeCreateSubrow<T>( in lookup, subrowId );
+        return UnsafeCreateSubrow< T >( in lookup, subrowId );
     }
 
     /// <inheritdoc/>
-    public bool Contains( SubrowCollection<T> item ) => ReferenceEquals( item.Sheet, this ) && HasRow( item.RowId );
+    public bool Contains( SubrowCollection< T > item ) => ReferenceEquals( item.Sheet, this ) && HasRow( item.RowId );
 
     /// <inheritdoc/>
-    public void CopyTo( SubrowCollection<T>[] array, int arrayIndex )
+    public void CopyTo( SubrowCollection< T >[] array, int arrayIndex )
     {
         ArgumentNullException.ThrowIfNull( array );
         ArgumentOutOfRangeException.ThrowIfNegative( arrayIndex );
         if( Count > array.Length - arrayIndex )
             throw new ArgumentException( "The number of elements in the source list is greater than the available space." );
         foreach( var lookup in OffsetLookupTable )
-            array[arrayIndex++] = new( this, in lookup );
+            array[ arrayIndex++ ] = new( this, in lookup );
     }
 
-    void ICollection<SubrowCollection<T>>.Add( SubrowCollection<T> item ) => throw new NotSupportedException();
+    void ICollection< SubrowCollection< T > >.Add( SubrowCollection< T > item ) => throw new NotSupportedException();
 
-    void ICollection<SubrowCollection<T>>.Clear() => throw new NotSupportedException();
+    void ICollection< SubrowCollection< T > >.Clear() => throw new NotSupportedException();
 
-    bool ICollection<SubrowCollection<T>>.Remove( SubrowCollection<T> item ) => throw new NotSupportedException();
+    bool ICollection< SubrowCollection< T > >.Remove( SubrowCollection< T > item ) => throw new NotSupportedException();
 
     /// <summary>Gets an enumerator that enumerates over all subrows.</summary>
     /// <returns>A new enumerator.</returns>
@@ -178,18 +178,18 @@ public sealed class SubrowExcelSheet<T>
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
     public Enumerator GetEnumerator() => new( this );
 
-    IEnumerator<SubrowCollection<T>> IEnumerable<SubrowCollection<T>>.GetEnumerator() => GetEnumerator();
+    IEnumerator< SubrowCollection< T > > IEnumerable< SubrowCollection< T > >.GetEnumerator() => GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>Represents an enumerator that iterates over all rows in a <see cref="SubrowExcelSheet{T}"/>.</summary>
     /// <param name="sheet">The sheet to iterate over.</param>
-    public struct Enumerator( SubrowExcelSheet<T> sheet ) : IEnumerator<SubrowCollection<T>>
+    public struct Enumerator( SubrowExcelSheet< T > sheet ) : IEnumerator< SubrowCollection< T > >
     {
         private int _index = -1;
 
         /// <inheritdoc cref="IEnumerator{T}.Current"/>
-        public readonly SubrowCollection<T> Current => new( sheet, in sheet.UnsafeGetRowLookupAt( _index ) );
+        public readonly SubrowCollection< T > Current => new( sheet, in sheet.UnsafeGetRowLookupAt( _index ) );
 
         readonly object IEnumerator.Current =>
             Current;
@@ -215,14 +215,14 @@ public sealed class SubrowExcelSheet<T>
 
     /// <summary>Represents an enumerator that iterates over all subrows in a <see cref="SubrowExcelSheet{T}"/>.</summary>
     /// <param name="sheet">The sheet to iterate over.</param>
-    public struct FlatEnumerator( SubrowExcelSheet<T> sheet ) : IEnumerator<T>, IEnumerable<T>
+    public struct FlatEnumerator( SubrowExcelSheet< T > sheet ) : IEnumerator< T >, IEnumerable< T >
     {
         private int _index = -1;
         private ushort _subrowIndex = ushort.MaxValue;
         private ushort _subrowCount;
 
         /// <inheritdoc cref="IEnumerator{T}.Current"/>
-        public readonly T Current => sheet.UnsafeCreateSubrowAt<T>( _index, _subrowIndex );
+        public readonly T Current => sheet.UnsafeCreateSubrowAt< T >( _index, _subrowIndex );
 
         readonly object IEnumerator.Current => Current;
 
@@ -266,7 +266,7 @@ public sealed class SubrowExcelSheet<T>
         /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
         public readonly FlatEnumerator GetEnumerator() => new( sheet );
 
-        readonly IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+        readonly IEnumerator< T > IEnumerable< T >.GetEnumerator() => GetEnumerator();
 
         readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/Lumina/Extensions/SpanExtensions.cs
+++ b/src/Lumina/Extensions/SpanExtensions.cs
@@ -30,12 +30,25 @@ public static class SpanExtensions
 #endif
     }
 
-    public static unsafe ref T UnsafeAt< T >( this Span< T > span, int index ) =>
+    /// <summary>Gets the reference to the item at the given index in the given span, without boundary checks.</summary>
+    /// <param name="span">Span to get an item reference from.</param>
+    /// <param name="index">Index of the item that should be at least <c>0</c> and at most <c>span.Length - 1</c>.</param>
+    /// <typeparam name="T">Type of elements.</typeparam>
+    /// <returns>Reference to the item at the given index in the span.</returns>
+    /// <remarks>If <paramref name="index"/> is negative or greater than or equal to <c>span.Length</c>, then the behavior is undefined.</remarks>
+    public static ref T UnsafeAt< T >( this Span< T > span, int index ) =>
         ref Unsafe.Add( ref MemoryMarshal.GetReference( span ), index );
 
-    public static unsafe ref readonly T UnsafeAt< T >( this ReadOnlySpan< T > span, int index ) =>
+    /// <inheritdoc cref="UnsafeAt{T}(Span{T}, int)"/>
+    public static ref readonly T UnsafeAt< T >( this ReadOnlySpan< T > span, int index ) =>
         ref Unsafe.Add( ref MemoryMarshal.GetReference( span ), index );
 
-    public static unsafe ref readonly T UnsafeAt< T >( this T[] array, int index ) =>
+    /// <summary>Gets the reference to the item at the given index in the given array, without boundary checks.</summary>
+    /// <param name="array">Array to get an item reference from.</param>
+    /// <param name="index">Index of the item that should be at least <c>0</c> and at most <c>array.Length - 1</c>.</param>
+    /// <typeparam name="T">Type of elements.</typeparam>
+    /// <returns>Reference to the item at the given index in the array.</returns>
+    /// <remarks>If <paramref name="index"/> is negative or greater than or equal to <c>array.Length</c>, then the behavior is undefined.</remarks>
+    public static ref T UnsafeAt< T >( this T[] array, int index ) =>
         ref Unsafe.Add( ref MemoryMarshal.GetArrayDataReference( array ), index );
 }

--- a/src/Lumina/Extensions/SpanExtensions.cs
+++ b/src/Lumina/Extensions/SpanExtensions.cs
@@ -30,12 +30,12 @@ public static class SpanExtensions
 #endif
     }
 
-    public static unsafe ref T UnsafeAt<T>( this Span<T> span, int index ) =>
+    public static unsafe ref T UnsafeAt< T >( this Span< T > span, int index ) =>
         ref Unsafe.Add( ref MemoryMarshal.GetReference( span ), index );
 
-    public static unsafe ref readonly T UnsafeAt<T>( this ReadOnlySpan<T> span, int index ) =>
+    public static unsafe ref readonly T UnsafeAt< T >( this ReadOnlySpan< T > span, int index ) =>
         ref Unsafe.Add( ref MemoryMarshal.GetReference( span ), index );
 
-    public static unsafe ref readonly T UnsafeAt<T>(this T[] array, int index) =>
+    public static unsafe ref readonly T UnsafeAt< T >( this T[] array, int index ) =>
         ref Unsafe.Add( ref MemoryMarshal.GetArrayDataReference( array ), index );
 }

--- a/src/Lumina/GameData.cs
+++ b/src/Lumina/GameData.cs
@@ -291,9 +291,9 @@ namespace Lumina
         /// <returns>An excel sheet corresponding to <typeparamref name="T"/> and <paramref name="language"/> that may be created anew or
         /// reused from a previous invocation of this method.</returns>
         /// <remarks>
-        /// <para>If the requested language doesn't exist for the file where <paramref name="language"/> is not <see cref="Language.None"/>, the language-neutral
-        /// sheet using <see cref="Language.None"/> will be loaded instead. If the language-neutral sheet does not exist, then the function will fail with
-        /// <see cref="UnsupportedLanguageException"/>.</para>
+        /// <para>If the requested language doesn't exist for the file where <paramref name="language"/> is not <see cref="Language.None"/>, the
+        /// language-neutral sheet using <see cref="Language.None"/> will be loaded instead. If the language-neutral sheet does not exist, then the function
+        /// will return <see langword="null"/>.</para>
         /// </remarks>
         /// <exception cref="InvalidCastException">Sheet is not of the variant <see cref="ExcelVariant.Default"/>.</exception>
         /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not have a valid <see cref="SheetAttribute"/>.</exception>
@@ -318,9 +318,9 @@ namespace Lumina
         /// <returns>An excel sheet corresponding to <typeparamref name="T"/> and <paramref name="language"/> that may be created anew or
         /// reused from a previous invocation of this method.</returns>
         /// <remarks>
-        /// <para>If the requested language doesn't exist for the file where <paramref name="language"/> is not <see cref="Language.None"/>, the language-neutral
-        /// sheet using <see cref="Language.None"/> will be loaded instead. If the language-neutral sheet does not exist, then the function will fail with
-        /// <see cref="UnsupportedLanguageException"/>.</para>
+        /// <para>If the requested language doesn't exist for the file where <paramref name="language"/> is not <see cref="Language.None"/>, the
+        /// language-neutral sheet using <see cref="Language.None"/> will be loaded instead. If the language-neutral sheet does not exist, then the function
+        /// will return <see langword="null"/>.</para>
         /// </remarks>
         /// <exception cref="InvalidCastException">Sheet is not of the variant <see cref="ExcelVariant.Subrows"/>.</exception>
         /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not have a valid <see cref="SheetAttribute"/>.</exception>


### PR DESCRIPTION
* `GetSheet` uses `MethodInfo.Invoke`, which will wrap the exception thrown by the target as `TargetInvocationException`. Fixed to handle wrapped exception types.
* `IEnumerator<T>.Current` is eagerly evaluated on `MoveNext` instead of lazily evaluationg from `get_Current`, to avoid the getter being called when the enumerator is in invalid state (including default) which will result in dereferencing null references.